### PR TITLE
remove "OK Lab" from map markers

### DIFF
--- a/js/GoogleMaps.js
+++ b/js/GoogleMaps.js
@@ -177,7 +177,8 @@
                 boxText.style.cssText = "white-space: nowrap;margin: 0px 8px;cursor:pointer;";
             } else boxText.style.cssText = "white-space: nowrap;margin: 0px 8px;";
 
-            boxText.innerHTML = obj.text;
+            // offset of 7 is for the removal of "OK Lab" to have less cluttered markers
+            boxText.innerHTML = obj.text.substr(7);
 
             var boxOptions = {
                 content: boxText


### PR DESCRIPTION
Vorher:
![untrimmed](https://cloud.githubusercontent.com/assets/245432/2840868/c9542392-d05d-11e3-9e9d-736d6714d21a.png)

Nachher:
![trimmed](https://cloud.githubusercontent.com/assets/245432/2840866/c346b0aa-d05d-11e3-81a8-fc845352dda6.png)

@juliakloiber @fotografiona Eure Meinung dazu?
