### PR TITLE
Added bundler install path and config directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@ cfg.sublime-workspace
 cfg.sublime-project
 css/scss/koala-config.json
 css/main.css.map
+vendor/bundle
 _site/
+.bundle
 .DS_Store
 .idea
 *.iml


### PR DESCRIPTION
I use Bundler to install all gems locally. These two additions help that local gems and Bundler configuration get not commited.
