### PR TITLE
Updated installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,46 @@
 # CodeFor.de
 
-## Install and run the site
+## Installation
 
-`git clone` the repo and install the dependencies:
+First `git clone` this repository.
+
+Then install the required gems. There are several ways to do this.
+
+### System-wide installation with Bundler
+
+You can use [Bundler](http://bundler.io/) to install the required gems system-wide:
 
     bundle install
-    # or without bundler
+
+### System-wide installation without Bundler
+
+Simply install the `github-pages` gem:
+
     gem install github-pages
 
-Then build the site and serve it:
+All required dependencies will be installed automatically. You will need root permissions to do that in most cases.
+
+### Local installation with Bundler
+
+If you don't want to install all the gems system-wide you can install them just for the project:
+
+    bundle install --path vendor/bundle
+
+On OS X you have to configure the following options to build `nokogiri` before running `bundle install`:
+
+    bundle config --local build.nokogiri --with-xml2-include=/usr/include/libxml2 --with-xml2-lib=/usr/lib --with-xslt-dir=/usr
+
+After that you can just run `bundle install` every time you want to reinstall or update the installation because Bundler will remember the options you configured.
+
+## Build and serve the site
+
+Now build the site and serve it:
 
     jekyll serve -w
 
+If you did the installation with Bundler you have to use this command instead:
+
+    bundle exec jekyll serve -w
 
 ## Download avatars
 


### PR DESCRIPTION
Split the installation instructions into different sections. Added a section to
explain how to do installation just for the project using Bundler.

Also added instructions how to run jekyll if Bundler has been used to install
the gems.
