### PR TITLE
fixed: empty project list shows head line

### DIFF
--- a/_layouts/lab.html
+++ b/_layouts/lab.html
@@ -103,7 +103,7 @@ layout: base
 <!-- Termine End -->
 
 <!-- Projekte -->
-{% unless project_count == 0 %}
+{% if project_count > 0 %}
 <div class="jumbotron fond__blue">
   <div class="container">
     <h3 id="projects">Projekte</h3> 
@@ -125,7 +125,7 @@ layout: base
     </div>
   </div>
 </div>
-{%endunless%}
+{% endif %}
 <!-- Projekte End -->
 
 <!-- Mitglieder-->


### PR DESCRIPTION
Problem right now: project headline is listed on lab page even if no projects are there. This PR fixes this problem.
![screenshot](https://cloud.githubusercontent.com/assets/1698836/3561663/3d6a30a0-09cf-11e4-9283-98f2d548df56.png)
