### PR TITLE
Update Termin OK Lab Hamburg

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -13,12 +13,12 @@
   month: September 2014
 
 - lab: OK Lab Hamburg
-  name: OK LAB HAMBURG CODING-TREFFEN
-  time: 18-22 Uhr
-  location: Open Data City, Alter Teichweg 33-35, 22081 Hamburg
+  name: PODIUMSDISKUSSION TRANSPARENZPORTAL
+  time: 19-21 Uhr
+  location: betahaus hamburg, Eifflerstraße 43,  22769 Hamburg
   day: Montag
-  day-nr: "22"
-  month: September 2014
+  day-nr: "6"
+  month: Oktober 2014
   link-url: http://pad.opendatacloud.de/p/OK-Lab-HH
   link-name: Mehr Info
 


### PR DESCRIPTION
Nächsten Termin für das OK Lab Hamburg eingetragen; wenn Ihr den bitte mergen mögt. :)
