### PR TITLE
Remove myself from OK Lab Stuttgart

### DIFF
--- a/stuttgart/index.html
+++ b/stuttgart/index.html
@@ -20,10 +20,6 @@ members:
 
 - name: Philip Fieber
 
-- name: Hans-Helge Bürger
-  username-twitter: obstschale
-  username-github: obstschale
-
 - name: Stefan Landsbek
   username-github: slandsbek
 


### PR DESCRIPTION
Ich wohne nicht länger in Stuttgart und kann deshalb auch nicht mehr am OK Lab Stuttgart teilnehmen. 
