### PR TITLE
Bonn: Schreibweise Nachname korrigiert

### DIFF
--- a/bonn/index.html
+++ b/bonn/index.html
@@ -16,7 +16,7 @@ members:
   username-github: opendatabonn
   username-twitter: eGovBonn
 
-- name: Sascha Förster
+- name: Sascha Foerster
   username-github: saschafoerster
   username-twitter: Sascha_Foerster
 


### PR DESCRIPTION
- Sascha heißt in der Tat Foerster mit oe, nicht mit ö.
