### PR TITLE
Bonn: Terminänderung 2 Treffen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ _site/
 .pyenv
 *.iml
 .sass-cache
+
+muenchen/hackathon/projekte/2014-11-19-Geoboundaries-München.html
+
+muenchen/hackathon/projekte/2014-11-19-Haushalt-München.html

--- a/_termine/OK_Lab_Bonn_Treffen.md
+++ b/_termine/OK_Lab_Bonn_Treffen.md
@@ -1,8 +1,8 @@
 ---
 lab: OK Lab Bonn
 name: OK Lab Bonn Treffen
-date: 2015-05-07 #YYYY-MM-DD
-time: 18-21 Uhr
-location: Stadthaus Bonn, Berliner Platz 2, 53111 Bonn
+date: 2015-04-16 #YYYY-MM-DD
+time: 19-21 Uhr
+location: Stadthaus Bonn, Berliner Platz 2, 53111 Bonn, Sitzungsraum 1
 link-url: http://www.meetup.com/OKLab-Bonn/events/221436272/
 ---

--- a/bonn/index.html
+++ b/bonn/index.html
@@ -54,6 +54,15 @@ links:
 - name: Twitter
   url: http://twitter.com/codeforbonn
 
+- name: Etherpad
+  url: https://pad.okfn.org/p/oklab-bonn
+
+- name: GitHub
+  url: https://github.com/OKLabBonn
+
+- name: Slack Team
+  url: https://codeforbonn.slack.com/
+
 
 leads:
 


### PR DESCRIPTION
Das 2. Treffen des OK Lab Bonn wird VORverlegt auf den 16.4.
