### PR TITLE
Bonn: Link zum OD Portal hinzugefuegt

### DIFF
--- a/bonn/index.html
+++ b/bonn/index.html
@@ -63,6 +63,9 @@ links:
 - name: Slack Team
   url: https://codeforbonn.slack.com/
 
+- name: OpenData Portal der Stadt Bonn
+  url: http://opendata.bonn.de
+
 
 leads:
 


### PR DESCRIPTION
Die Stadt Bonn hat ein offizielles OpenData Portal.
Link hinzugefuegt.
