### PR TITLE
No more need to remove the ok lab's page.

### DIFF
--- a/_layouts/lab.html
+++ b/_layouts/lab.html
@@ -144,8 +144,6 @@ layout: base
   {% endif %}
 {% endfor %}
 
-<!-- remove the ok lab's page -->
-{% capture project_count %}{{ project_count | minus:1 }}{% endcapture %}
 {% unless project_count == '0' %}
 <div class="jumbotron fond__blue">
   <div class="container">


### PR DESCRIPTION
Since PR #398 lab pages don't have a variable named `lab` any more.  Therefore lab pages are not counted as projects.

The breaking commit for OK Lab Stuttgart was 6c7b1badca10e9ea7010b8dc0f2f133498614d14.

Fixes #404
