### PR TITLE
Code Of Conduct signed for OK Lab Bonn

### DIFF
--- a/code-of-conduct/index.html
+++ b/code-of-conduct/index.html
@@ -42,6 +42,8 @@ footerlogos: yes
             <li>Marcel Belledin, Köln</li>
             <li>Mario Haim, München</li>
             <li>Jan A. Lutz, Stuttgart</li>
+            <li>Sven Hense, Bonn</li>
+            <li>Stefan Wolfrum, Bonn</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Sven Hense und Stefan Wolfrum (Lab Leads Bonn) unterzeichnen den Code
Of Conduct.
