### PR TITLE
Fixed links to english version

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -100,14 +100,25 @@
         {% else %}
           {% assign topdir = page.url | replace_first:'/',''| split:"/" | first %}
           {% assign urllength = page.url | size %}
-          {% if topdir == 'blog' or topdir == 'presse' or topdir == 'impressum' or topdir == 'stadtgeschichten' %}
+	  {% case topdir %}
+          {% when 'blog' or 'presse' or 'impressum' or 'ressourcen' or 'stadtgeschichten' %}
             <a href="/en/">EN</a>
-          {% elsif topdir == 'projekte' and urllength > 25 %}
-            <a href="/en/">EN</a>
+          {% when 'projekte' %}
+            {% if urllength > 25 %}
+              <a href="/en/">EN</a>
+            {% else %}
+              <a href="/en{{page.url | replace:'index.html',''}}">EN</a>
+            {% endif %}
+          {% when 'muenchen' %}
+            {% if urllength > 20 %}
+              <a href="/en/">EN</a>
+            {% else %}
+              <a href="/en{{page.url | replace:'index.html',''}}">EN</a>
+            {% endif %}
           {% else %}
             <a href="/en{{page.url | replace:'index.html',''}}">EN</a>
-          {% endif %}
-        {% endif%}
+          {% endcase %}
+        {% endif %}
         </li>
       </ul>
 

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -99,10 +99,13 @@
           <a href="{{page.url | replace:'/en','' | replace:'index.html',''}}">DE</a>
         {% else %}
           {% assign topdir = page.url | replace_first:'/',''| split:"/" | first %}
-          {% if topdir != 'blog' and topdir != 'presse' and topdir != 'impressum' and topdir != 'stadtgeschichten' %}
-            <a href="/en{{page.url | replace:'index.html',''}}">EN</a>
-          {% else %}
+          {% assign urllength = page.url | size %}
+          {% if topdir == 'blog' or topdir == 'presse' or topdir == 'impressum' or topdir == 'stadtgeschichten' %}
             <a href="/en/">EN</a>
+          {% elsif topdir == 'projekte' and urllength > 25 %}
+            <a href="/en/">EN</a>
+          {% else %}
+            <a href="/en{{page.url | replace:'index.html',''}}">EN</a>
           {% endif %}
         {% endif%}
         </li>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -96,12 +96,13 @@
         <li class="text-center nav-meta-social"><a href="https://github.com/okfde/codefor.de" ><img src="/img/GitHub-Mark-Light-32px.png" alt="The infamous Octocat" width="32" height="32" ></a></li>
         <li class="text-center nav-meta-lang">
         {% if page.lang == 'en' %}
-        <a href="{{page.url | replace:'/en','' | replace:'index.html',''}}">DE</a>
+          <a href="{{page.url | replace:'/en','' | replace:'index.html',''}}">DE</a>
         {% else %}
-          {% if page.url != '/blog/index.html' and page.url != '/presse/index.html' and page.url != '/impressum/index.html' and != '/stories/index.html' %}
-          <a href="/en{{page.url | replace:'index.html',''}}">EN</a>
+          {% assign topdir = page.url | replace_first:'/',''| split:"/" | first %}
+          {% if topdir != 'blog' and topdir != 'presse' and topdir != 'impressum' and topdir != 'stadtgeschichten' %}
+            <a href="/en{{page.url | replace:'index.html',''}}">EN</a>
           {% else %}
-          <a href="/en/">EN</a>
+            <a href="/en/">EN</a>
           {% endif %}
         {% endif%}
         </li>


### PR DESCRIPTION
While the link “English version” for [/blog/](http://codefor.de/blog/) (no translation available) pointed to [/en/](http://codefor.de/en/), the link “English version” for a blog post pointed to a nonexistent english blog post.  E.g., for [/blog/pen-and-paper-hackathon-in-koeln/](http://codefor.de/blog/pen-and-paper-hackathon-in-koeln/) the link “English version” pointed to [/en/blog/pen-and-paper-hackathon-in-koeln/](http://codefor.de/en/blog/pen-and-paper-hackathon-in-koeln/).

This led to 404 Not found errors.

For projects, there are the pages [/en/projekte/](http://codefor.de/en/projekte/) and [/en/projekte/alle/](http://codefor.de/en/projekte/alle/), but no english page exists for a specific project.
