### PR TITLE
fix(blog-post): add missing excerpt

### DIFF
--- a/_posts/2014-05-23-oklab-muenster.md
+++ b/_posts/2014-05-23-oklab-muenster.md
@@ -3,6 +3,7 @@ layout: post
 
 title: Das OK Lab Muenster
 author: Fiona
+excerpt: Welche Köpfe stecken eigentlich hinter dem OK Lab Müster? 
 
 ---
 


### PR DESCRIPTION
Add missing excerpt. Without excerpt the description meta tag is broken: http://codefor.de/blog/oklab-muenster/
