### PR TITLE
Update lab leipzig location

### DIFF
--- a/_labs/leipzig.yml
+++ b/_labs/leipzig.yml
@@ -2,8 +2,8 @@
 key: leipzig
 title: OK Lab Leipzig
 lab: OK Lab Leipzig
-lat: 51.329594
-long: 12.327738
+lat: 51.3322131
+long: 12.3735576
 markerposition: right
 h4c: true
 

--- a/en/leipzig/index.html
+++ b/en/leipzig/index.html
@@ -7,4 +7,4 @@ lang: en
 # german text is in leipzig/index.html
 ---
 
-The OK lab Leipzig meets every Monday at 19:00 at the BIC to work together on open data apps for Leipzig. Newcomers and people who do not program are always welcome! An input session takes place on the second Monday of every month. On this day, we invite external speakers, introduce technologies and concepts or work together across the project.
+The OK lab Leipzig meets every Monday at 19:00 in the [Basislager Coworking](http://www.basislager.co/) to work together on open data apps for Leipzig. Newcomers and people who do not program are always welcome! An input session takes place on the second Monday of every month. On this day, we invite external speakers, introduce technologies and concepts or work together across the project.

--- a/leipzig/index.html
+++ b/leipzig/index.html
@@ -6,7 +6,7 @@ key: leipzig
 # english text is in en/leipzig/index.html
 ---
 
-Das OK Lab Leipzig trifft sich jeden Montag um 19:00 Uhr im [BIC](http://www.bic-leipzig.de/kontakt-wegbeschreibung.html), um gemeinsam an Open Data Apps für Leipzig zu arbeiten. Neueinsteigerinnen und Leute, die nicht programmieren, sind immer herzlich willkommen!
+Das OK Lab Leipzig trifft sich jeden Montag um 19:00 Uhr im [Basislager Coworking](http://www.basislager.co/), um gemeinsam an Open Data Apps für Leipzig zu arbeiten. Neueinsteigerinnen und Leute, die nicht programmieren, sind immer herzlich willkommen!
 
 Am zweiten Montag im Monat findet eine Input-Session statt. Hier laden wir externe Referentinnen ein, stellen selbst Technologien und Konzepte vor oder arbeiten Projekt-übergreifend zusammen.
 

--- a/projekte/2014-07-13-le-ratskarte_leipzig.html
+++ b/projekte/2014-07-13-le-ratskarte_leipzig.html
@@ -19,7 +19,14 @@ collaborators:
   links:
   - url: https://github.com/ahx
     url-name: github
-- name: Dr4k3
+- name: Martin Stoffers
+  links:
+  - url: https://github.com/drake81
+    url-name: github
+- name: Jörg Reichert
+  links:
+  - url: https://github.com/joergreichert
+    url-name: github
 ---
 
 Durchsuche das Ratsinformationssystem der Stadt Leipzig und abboniere deine Suchergebnisse!


### PR DESCRIPTION
Updated location of OKLab Leipzig to Basislager Coworking. Also some updates to project members.
