### PR TITLE
fix meta description content on stories pages

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -23,7 +23,7 @@
     {{ site.title }}  ~ {{ site.description }}
   {% endif %}</title>
 
-  <meta name="description" content="{{ page.excerpt }}">
+  <meta name="description" content="{{ page.excerpt | strip_html }}">
   <meta name="viewport" content="width=device-width">
 
   {% include head-social-og.html %}
@@ -65,7 +65,7 @@
     s.parentNode.insertBefore(wf, s);
   })();
 
-  </script> 
+  </script>
 
 </head>
 


### PR DESCRIPTION
came across this following visual glitch browsing the http://codefor.de/stadtgeschichten/ sub-pages:

![bildschirmfoto 2016-02-27 um 19 52 31](https://cloud.githubusercontent.com/assets/34942/13374668/aecf6ed6-dd8b-11e5-8f57-d04706d8920a.png)
