### PR TITLE
Tippfehler

### DIFF
--- a/projekte/2016-06-13-cologne-sagsunskoeln.html
+++ b/projekte/2016-06-13-cologne-sagsunskoeln.html
@@ -2,7 +2,7 @@
 layout: project
 lab: OK Lab Köln #needed for Aggregation on Lab-Page
 imgname: koeln/sagsunsapp-logo.png
-title: KVB Fahrräder in Köln
+title: Sag's uns App Köln
 status: Laufend
 
 links:


### PR DESCRIPTION
wahrscheinlich durch Copy'n'Paste noch "KVB-Fahrräder" in der Beschreibung der Sag's uns App
