### PR TITLE
fix: link to the intended external site

### DIFF
--- a/projekte/2016-07-23-metacollect.html
+++ b/projekte/2016-07-23-metacollect.html
@@ -9,7 +9,7 @@ published: true #set to 'true'
 
 
 links:
-- url: metacollect.org
+- url: http://metacollect.org
   name: Website
 - url: https://github.com/metacollect-org/
   name: Page on Github


### PR DESCRIPTION
Create a link to the intended external page http://metacollect.org, instead of the 404 relative page http://codefor.de/projekte/metacollect.org