### PR TITLE
Korrektur von Links zu Github und zu wo-ist-markt.de

### DIFF
--- a/projekte/2015-03-02-ka-woistmarkt.html
+++ b/projekte/2015-03-02-ka-woistmarkt.html
@@ -6,7 +6,7 @@ title: Wo ist Markt?
 status: Finished
 
 links:
-- url: http://wo-ist-markt.de/karlsruhe
+- url: http://wo-ist-markt.de/#karlsruhe
   name: Wo ist Markt in Karlsruhe?
 - url: https://github.com/wo-ist-markt/wo-ist-markt.github.io
   name: Code auf Github

--- a/projekte/2015-03-02-ka-woistmarkt.html
+++ b/projekte/2015-03-02-ka-woistmarkt.html
@@ -6,9 +6,9 @@ title: Wo ist Markt?
 status: Finished
 
 links:
-- url: http://codeforkarlsruhe.github.io/wo-ist-markt/
+- url: http://wo-ist-markt.de/karlsruhe
   name: Wo ist Markt in Karlsruhe?
-- url: https://github.com/CodeforKarlsruhe/wo-ist-markt
+- url: https://github.com/wo-ist-markt/wo-ist-markt.github.io
   name: Code auf Github
 
 collaborators:


### PR DESCRIPTION
Links bei dem Projekt haben zu falschen oder nicht mehr existierenden Seiten geführt.