### PR TITLE
Projects reverse sorting

### DIFF
--- a/_layouts/lab.html
+++ b/_layouts/lab.html
@@ -101,7 +101,7 @@ layout: base
 
 <!-- Projekte -->
 {% assign sorted_projects = site.pages | where_exp:"sitepage","sitepage.lab contains meta.lab" | where:"layout","project" | sort: 'date' %}
-{% if meta.projectsorder == 'reverse' %}
+{% if meta.projectsorder != 'reverse' %}
   {% assign sorted_projects = sorted_projects | reverse %}
 {% endif %}
 

--- a/projekte/alle/index.html
+++ b/projekte/alle/index.html
@@ -12,7 +12,8 @@ title: Alle Projekte
       <span class="h4 pull-right"><a href="/projekte">Projekt Showcase …</a></span>
     </div>
 
-    {% for sitepage in site.pages %}
+    {% assign sorted_site_pages = site.pages | sort: 'date' | reverse %}
+    {% for sitepage in sorted_site_pages %}
       {% if sitepage.layout == 'project' %}
         {% include project-teaser-slim.html %}
       {% endif %}

--- a/projekte/index.html
+++ b/projekte/index.html
@@ -20,7 +20,8 @@ title: Projekt Showcase
 
 
       <div class="packery-item-gutter"></div>
-      {% for sitepage in site.pages %}
+      {% assign sorted_site_pages = site.pages | sort: 'date' | reverse %}
+      {% for sitepage in sorted_site_pages %}
       {% if sitepage.showcase and sitepage.layout == 'project' %}
         <div class="packery-item" >
           {% include project-teaser.html %}


### PR DESCRIPTION
- Visitors should see **new** projects on the **top** of the page instead of the bottom.
- Applied to "Projekte", "Alle Projekte" and city scoped project pages.

# Review needed! :eyes: 
- [ ] Please check if the individual project pages render the projects in reverse chronological order.
- [ ] Please check if the "Projekte" page, "Alle Projekte" pages render the projects in reverse chronological order.
- [ ] Please check that the [specific sorting setting for Köln](https://github.com/okfde/codefor.de/blob/gh-pages/_labs/koeln.yml#L8) still renders as configured.

# Related issues / pull requests
- #509, #666  

---

feat. @k-nut 