### PR TITLE
Fix broken image at top of city page

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@ footerlogos: yes
 
 <!-- Wahlsalon Teaser -->
 <div class="hero-container ws-teaser">
-  <a href="/wahlsalons"><img class="img-responsive" style="width: 100%;" src="img/wahlsalons_banner.svg"></a>
+  <a href="/wahlsalons"><img class="img-responsive" style="width: 100%;" src="/img/wahlsalons_banner.svg"></a>
 </div>
 
 <!-- Lab Map -->


### PR DESCRIPTION
The top of https://codefor.de/en/heidelberg/ contains a link to `/wahlsalons`, which has an `img` child element pointing to `img/wahlsalons_banner.svg`, which does not display in my browser. When I follow this relative link to `https://codefor.de/en/heidelberg/img/wahlsalons_banner.svg`, I land on the same page, which is not an image. https://codefor.de//img/wahlsalons_banner.svg does exist and is an image. The link should thus be absolute.