### PR TITLE
Remove not-link from Hamburg

### DIFF
--- a/_labs/hamburg.yml
+++ b/_labs/hamburg.yml
@@ -74,9 +74,6 @@ links:
 - name: Mailingliste - NEU
   url: http://codeforhamburg.org/newsletter/
 
-- name: "--------------------------------" 
-  url: 
-
 - name: Termine (Meetup.com)
   url: http://www.meetup.com/codeforhamburg
 


### PR DESCRIPTION
Found that when looking at the geojson