### PR TITLE
Website von Code For Heilbronn hinzugefügt

### DIFF
--- a/_labs/heilbronn.yml
+++ b/_labs/heilbronn.yml
@@ -76,6 +76,8 @@ links:
   url: https://twitter.com/codeforhn
 - name: Coworking Space Heilbronn
   url: http://coworking-heilbronn.org/
+- name: Code For Heilbronn Website
+  url: codeforheilbronn.de
 
 leads:
 - name: Felix Ebert


### PR DESCRIPTION
Wir haben mittlerweile eine eigene Website. Die habe ich mal zu den Links oben hinzugefügt.