### PR TITLE
Update berlin.yml

### DIFF
--- a/_labs/berlin.yml
+++ b/_labs/berlin.yml
@@ -199,7 +199,7 @@ links:
 - name: Twitter
   url: http://twitter.com/codeforbe
 - name: Mailingliste
-  url: https://lists.okfn.org/mailman/listinfo/codeforberlin
+  url: https://mlists.okfn.de/cgi-bin/mailman/listinfo/codeforberlin
 
 
 leads:


### PR DESCRIPTION
Alte Mailingliste wurde stillgelegt.

Siehe https://lists.okfn.org/mailman/private/codeforberlin/2018-May/000698.html