### PR TITLE
Fix deprecation warning in the jekyll config file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ permalink: /blog/:title.html
 excerpt_separator: "\n"
 paginate: 5
 paginate_path: "blog/:num"
-gems:
+plugins:
   - jekyll-sitemap
   - jekyll-paginate
 collections:


### PR DESCRIPTION
The build printed: "Deprecation: The 'gems' configuration option has been renamed to 'plugins'"

This PR does this simple fix