### PR TITLE
Optimize build time of the page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
+gem 'jekyll-include-cache', group: :jekyll_plugins

--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,7 @@ title: "Code for Germany"
 description: "Stadt&lt;entwickler /&gt; nutzen offene Daten um ihre Stadt zu verbessern"
 url: http://codefor.de
 markdown: kramdown
+keep_files: [img, assets]
 exclude:
   - "vendor"
   - "CNAME"
@@ -22,6 +23,7 @@ paginate_path: "blog/:num"
 gems:
   - jekyll-sitemap
   - jekyll-paginate
+  - jekyll-include-cache
 collections:
   labs:
   stories:

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -27,7 +27,7 @@
   <meta name="description" content="{{ page.excerpt | strip_html }}">
   <meta name="viewport" content="width=device-width">
 
-  {% include head-social-og.html %}
+  {% include_cached head-social-og.html %}
 
   <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/css/bootstrap.min.css">
@@ -183,6 +183,6 @@ $(document).ready(function() {
   });
 </script>
 
-{% include piwik.html %}
+{% include_cached piwik.html %}
 </body>
 </html>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -17,7 +17,7 @@ layout: base
       </div>
 
       <div class="col-lg-4 blog-sidebar" >
-        {% include twitter-feed.html  %}
+        {% include_cached twitter-feed.html  %}
 
         <img src="/assets/blog/flyer1.jpg" class="img-responsive" alt="">
 

--- a/_layouts/lab.html
+++ b/_layouts/lab.html
@@ -111,7 +111,7 @@ layout: base
 <script src="/js/lib/prettyCheckbox.min.js"></script>
 
 {% if meta.lat and meta.long %}
-  {% include_cached leaflet-city.html %}
+  {% include leaflet-city.html %}
 {% endif %}
 
 <script type="text/javascript">

--- a/_layouts/lab.html
+++ b/_layouts/lab.html
@@ -111,7 +111,7 @@ layout: base
 <script src="/js/lib/prettyCheckbox.min.js"></script>
 
 {% if meta.lat and meta.long %}
-  {% include leaflet-city.html %}
+  {% include_cached leaflet-city.html %}
 {% endif %}
 
 <script type="text/javascript">

--- a/_layouts/map-iframe.html
+++ b/_layouts/map-iframe.html
@@ -74,6 +74,6 @@
   </div>
 
 
-{% include piwik.html %}
+{% include_cached piwik.html %}
 </body>
 </html>

--- a/_layouts/story.html
+++ b/_layouts/story.html
@@ -9,13 +9,13 @@ layout: base
       <div class="story--pattern-wrap">
         {% case page.pattern %}
             {% when 1 %}
-              {% include inline-svg/story_wallpaper_1.svg %}
+              {% include_cached inline-svg/story_wallpaper_1.svg %}
             {% when 2 %}
-              {% include inline-svg/story_wallpaper_2.svg %}
+              {% include_cached inline-svg/story_wallpaper_2.svg %}
             {% when 3 %}
-              {% include inline-svg/story_wallpaper_3.svg %}
+              {% include_cached inline-svg/story_wallpaper_3.svg %}
             {% else %}
-              {% include inline-svg/story_wallpaper_1.svg %}
+              {% include_cached inline-svg/story_wallpaper_1.svg %}
         {% endcase %}
       </div>
     </div>

--- a/en/index.html
+++ b/en/index.html
@@ -8,7 +8,7 @@ lang: en
 <div class="hero-container fond__blue">
     <div class="hero-pattern">
       <div class="hero-pattern-wrap">
-        {% include inline-svg/optimized/stories_header.svg %}
+        {% include_cached inline-svg/optimized/stories_header.svg %}
       </div>
    </div>
     <div id="animation-wrapper" class="text-center">
@@ -58,11 +58,11 @@ lang: en
 
 
 <!-- Newsletter -->
-{% include newsletter-form.html %}
+{% include_cached newsletter-form.html %}
 
 <script src="/js/lib/jquery.cookie.js"></script>
 
-{% include leaflet.html %}
+{% include_cached leaflet.html %}
 
 <script type="text/javascript">
   

--- a/en/mitmachen/index.html
+++ b/en/mitmachen/index.html
@@ -88,4 +88,4 @@ lang: en
   </div>
 </div>
 <!-- Newsletter -->
-{% include newsletter-form.html %}
+{% include_cached newsletter-form.html %}

--- a/en/stadtgeschichten/index.html
+++ b/en/stadtgeschichten/index.html
@@ -13,15 +13,15 @@ og-image: /img/stories-wallpaper-og-img.png
       <div class="story-teaser--image">
         {% case story.pattern %}
         {% when 1 %}
-          {% include inline-svg/optimized/story_teaser_1.svg %}
+          {% include_cached inline-svg/optimized/story_teaser_1.svg %}
         {% when 2 %}
-          {% include inline-svg/optimized/story_teaser_2.svg %}
+          {% include_cached inline-svg/optimized/story_teaser_2.svg %}
         {% when 3 %}
-          {% include inline-svg/optimized/story_teaser_3.svg %}
+          {% include_cached inline-svg/optimized/story_teaser_3.svg %}
         {% when 4 %}
-          {% include inline-svg/optimized/story_teaser_4.svg %}
+          {% include_cached inline-svg/optimized/story_teaser_4.svg %}
         {% else %}
-          {% include inline-svg/optimized/story_teaser_1.svg %}
+          {% include_cached inline-svg/optimized/story_teaser_1.svg %}
         {% endcase %}
       </div>
       <div class="story-teaser--title text-center">

--- a/mitmachen/index.html
+++ b/mitmachen/index.html
@@ -89,4 +89,4 @@ title: "Mach mit!"
   </div>
 </div>
 <!-- Newsletter -->
-{% include newsletter-form.html %}
+{% include_cached newsletter-form.html %}

--- a/stadtgeschichten/index.html
+++ b/stadtgeschichten/index.html
@@ -11,15 +11,15 @@ og-image: /img/stories-wallpaper-og-img.png
 			<div class="story-teaser--image">
 				{% case story.pattern %}
 				    {% when 1 %}
-						{% include inline-svg/optimized/story_teaser_1.svg %}
+						{% include_cached inline-svg/optimized/story_teaser_1.svg %}
 				    {% when 2 %}
-				    	{% include inline-svg/optimized/story_teaser_2.svg %}
+				    	{% include_cached inline-svg/optimized/story_teaser_2.svg %}
 				    {% when 3 %}
-				    	{% include inline-svg/optimized/story_teaser_3.svg %}
+				    	{% include_cached inline-svg/optimized/story_teaser_3.svg %}
 				    {% when 4 %}
-				    	{% include inline-svg/optimized/story_teaser_4.svg %}
+				    	{% include_cached inline-svg/optimized/story_teaser_4.svg %}
 				    {% else %}
-				    	{% include inline-svg/optimized/story_teaser_1.svg %}
+				    	{% include_cached inline-svg/optimized/story_teaser_1.svg %}
 				{% endcase %}
 			</div>
 			<div class="story-teaser--title text-center">


### PR DESCRIPTION
This PR adds:

- The keep_files config option for the folders img and assets
- add the [jekyll-include-cache](https://github.com/benbalter/jekyll-include-cache) plugin and sets it up (this does work on github)

On my PC it did make the build twice as fast as before. While this doesn't matter on Github it does matter if you want to try something locally.

The Plugin basicly causes that things that get multiple times include but are always the same get build once and not for every page using a specific layout.
The keep_files prevents the build from looking at the files, as thoose only need to be copied and not modified while building.