### PR TITLE
replace packery in projects page with multi-col layout

### DIFF
--- a/_layouts/lab.html
+++ b/_layouts/lab.html
@@ -69,16 +69,9 @@ layout: base
   <div class="jumbotron fond__blue">
     <div class="container">
       <h3 id="projects">{% if page.lang == 'en' %}Projects{% else %}Projekte{% endif%}</h3>
-      <div class="loading">
-        <i class="fa fa-circle-o-notch fa-spin"></i>
-        <div>...{% if page.lang == 'en' %}loading{% else %}laden{% endif %}...</div>
-      </div>
-      <div class="packery-container">
-        <div class="packery-item-gutter"></div>
+      <div class="project-list">
         {% for sitepage in sorted_projects %}
-          <div class="packery-item" >
-            {% include project-teaser.html type='page' %}
-          </div>
+          {% include project-teaser.html type='page' %}
         {% endfor %}
       </div>
     </div>
@@ -116,7 +109,6 @@ layout: base
 
 <script type="text/javascript">
 $(document).ready(function() {
-  packery = new PackeryGrid('.packery-container','.packery-item', '.packery-item-gutter');
   $(":checkbox").prettyCheckbox();
 });
 </script>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -839,6 +839,16 @@ $date-circle: 80px;
 =            Projects           =
 ===============================*/
 
+.project-list {
+  column-width: 420px;
+  column-gap: 32px;
+}
+
+
+.project-teaser {
+  display: inline-block;
+  width: 100%;
+}
 
 .project-teaser-slim .image-crop {
 	position: relative;


### PR DESCRIPTION
This PR replaces the packery JS library in the project view with the native multi-column layout. It has multiple advantages:
- does not require javascript
- loads much faster
- handles resizes better/faster

But also has the disadvantage that we cannot be sure about the project order anymore. I think previously the projects would show up like this:
```
1 2
3 4
5 6
``` 
where they might now show up like this since they are filled column by column:
```
1 4
2 5
3 6
```

I'm happy to discuss if you all think this is a good idea or not. If we agree that it is a good idea, I'll also replace all other occurrences of packery.

Reference (where I got the idea to do this): https://www.smashingmagazine.com/2019/01/css-multiple-column-layout-multicol/




## new 
|  old | new  | 
|-----|------|
| ![](https://screenshotscdn.firefoxusercontent.com/images/446db8f8-da07-40bd-88d5-f38a6e25cbac.jpg) | ![](https://screenshotscdn.firefoxusercontent.com/images/af8b0801-2e5a-4f97-8ac1-ebeea93b7c50.jpg)  | 