### PR TITLE
disable caching for sharing-meta tags

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -27,7 +27,7 @@
   <meta name="description" content="{{ page.excerpt | strip_html }}">
   <meta name="viewport" content="width=device-width">
 
-  {% include_cached head-social-og.html %}
+  {% include head-social-og.html %}
 
   <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/css/bootstrap.min.css">


### PR DESCRIPTION
the `head-social-og.html` template actually depends on the
current page and therefore cannot simply be cached.

By removing this cache we actually properly render the meta
tags that are required for facebook/twitter/etc. again