### PR TITLE
add banner for global climate strike

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -35,7 +35,10 @@
   <link rel="stylesheet" href="/css/main.css?v=1.7">
   <link rel="icon" href="/favicon.ico" type="image/x-icon" />
   <link rel="alternate" type="application/rss+xml" title="Blog | {{ site.title }}" href="/feed.xml">
-
+  
+  <!-- banner for global climate strike on September 20th, 2019 -->
+  <script src="https://assets.digitalclimatestrike.net/widget.js" async></script>
+  
   <script src="/js/lib/modernizr-2.8.3-respond-1.4.2.min.js"></script>
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
   <script>window.jQuery || document.write('<script src="js/lib/jquery-1.10.1.min.js"><\/script>')</script>


### PR DESCRIPTION
Fügt ein Banner am Fuß hinzu, dass dazu aufruft, am 20.9. am globalen Klimastreik teilzunehmen (s. https://codeformuenster.org). Das Banner legt sich am 20.9. im Vollbild über die Seite und macht sie so an dem Tag unbenutzbar (lässt sich auch wegklickbar konfigurieren).
Mehr Infos: https://digital.globalclimatestrike.net/