### PR TITLE
berlin: update contact information

### DIFF
--- a/_labs/berlin.yml
+++ b/_labs/berlin.yml
@@ -199,11 +199,5 @@ links:
 
 
 leads:
-- name: Tobi
-  url: mailto:tobias.preuss@googlemail.com
-- name: Jochen
-  url: mailto:jochen.klar@gmail.com
-- name: Thomas
-  url: mailto:thomas@tursics.de
-- name: Knut
-  url: mailto:knut@k-nut.eu
+- name: E-Mail
+  url: mailto:berlin@codefor.de


### PR DESCRIPTION
Some time ago, we (Berlin lab) decided that we would rather have one generic e-mail address for people to contact our lab rather than all individual lab leads, because it might be confusing for outsiders to decide who to concact out of four or five people.

FYI: The new lab lead mailing list (`berlin@codefor.de`) currently includes Knut, Tobi, Jochen and me.